### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -1,5 +1,8 @@
 name: SAST CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/guilhermelinosp/yarp-worker/security/code-scanning/1](https://github.com/guilhermelinosp/yarp-worker/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow does not perform any write operations on the repository, we can set `contents: read` at the workflow level. This ensures that the `GITHUB_TOKEN` has only read access to the repository contents.

The `permissions` block should be added at the root level of the workflow file, so it applies to all jobs unless overridden by job-specific permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
