### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 env:
   SONAR_PROJECT_KEY: "guilhermelinosp_yarp-worker_a2c93dff-a9c3-4e98-a7cd-d89135f556d1"
   SONAR_SCANNER_DIR: ".sonar/scanner"


### PR DESCRIPTION
Potential fix for [https://github.com/guilhermelinosp/yarp-worker/security/code-scanning/3](https://github.com/guilhermelinosp/yarp-worker/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow primarily reads repository contents and does not perform write operations, we can set `contents: read` at the root level of the workflow. This will apply to all jobs unless overridden by a job-specific `permissions` block.

The changes will be made to the `.github/workflows/sonarqube.yml` file. Specifically:
1. Add a `permissions` block at the root level of the workflow, immediately after the `on` block.
2. Set `contents: read` as the permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
